### PR TITLE
Renamed Task to SCTask

### DIFF
--- a/Sources/ShortcutFoundation/Core/Task Flow/SCTask.swift
+++ b/Sources/ShortcutFoundation/Core/Task Flow/SCTask.swift
@@ -8,14 +8,14 @@
 
 import Foundation
 
-public protocol TaskFlow {
+public protocol SCTaskFlow {
     func finish()
     func finish<T>(_ result: T)
     func finish(_ error: Error)
     func cancel()
 }
 
-public enum TaskState<LastResult> {
+public enum SCTaskState<LastResult> {
     case queued
     case running(LastResult?)
     case canceled
@@ -23,8 +23,8 @@ public enum TaskState<LastResult> {
     case finished(LastResult?)
 }
 
-public final class Task {
-    public typealias Callback = (TaskFlow, Any?) -> Void
+public final class SCTask {
+    public typealias Callback = (SCTaskFlow, Any?) -> Void
     fileprivate let callback: Callback
     fileprivate let runOnBackground: Bool
     
@@ -33,7 +33,7 @@ public final class Task {
         callback = closure
     }
     
-    public func run(flow: TaskFlow, previousResult result: Any?) {
+    public func run(flow: SCTaskFlow, previousResult result: Any?) {
         guard runOnBackground else { callback(flow, result); return }
         
         DispatchQueue.global(qos: DispatchQoS.QoSClass.utility).async {

--- a/Sources/ShortcutFoundation/Core/Task Flow/SCTaskSequence.swift
+++ b/Sources/ShortcutFoundation/Core/Task Flow/SCTaskSequence.swift
@@ -8,10 +8,10 @@
 
 import Foundation
 
-public final class TaskSequence {
-    fileprivate var tasks: [Task]
+public final class SCTaskSequence {
+    fileprivate var tasks: [SCTask]
     
-    public typealias FinishCallback = (TaskState<Any>?) -> Void
+    public typealias FinishCallback = (SCTaskState<Any>?) -> Void
     public typealias ErrorCallback = (Error) -> Void
     public typealias CancelCallback = () -> Void
     
@@ -19,23 +19,23 @@ public final class TaskSequence {
     fileprivate var errorCallback: ErrorCallback?
     fileprivate var cancelCallback: CancelCallback?
     
-    fileprivate var currentState: TaskState<Any>? = .queued
+    fileprivate var currentState: SCTaskState<Any>? = .queued
     fileprivate let syncQueue = DispatchQueue(label: "io.shortcut.syncQueue",
                                               attributes: DispatchQueue.Attributes.concurrent)
     
-    public var state: TaskState<Any>? {
-        var val: TaskState<Any>?
+    public var state: SCTaskState<Any>? {
+        var val: SCTaskState<Any>?
         syncQueue.sync {
             val = self.currentState
         }
         return val
     }
     
-    public init(tasks: [Task]) {
+    public init(tasks: [SCTask]) {
         self.tasks = tasks
     }
     
-    public init(tasks: Task...) {
+    public init(tasks: SCTask...) {
         self.tasks = tasks
     }
     
@@ -76,7 +76,7 @@ public final class TaskSequence {
     deinit {}
 }
 
-extension TaskSequence: TaskFlow {
+extension SCTaskSequence: SCTaskFlow {
     public func finish() {
         guard case .running = state else {
             return
@@ -92,7 +92,7 @@ extension TaskSequence: TaskFlow {
             return
         }
         
-        var task: Task?
+        var task: SCTask?
         syncQueue.sync(flags: .barrier) {
             self.currentState = .running(nil)
             task = self.tasks.first
@@ -116,7 +116,7 @@ extension TaskSequence: TaskFlow {
             return
         }
         
-        var task: Task?
+        var task: SCTask?
         syncQueue.sync(flags: .barrier) {
             self.currentState = .running(result)
             task = self.tasks.first

--- a/Tests/ShortcutFoundationTests/TaskFlowTests.swift
+++ b/Tests/ShortcutFoundationTests/TaskFlowTests.swift
@@ -8,13 +8,13 @@ final class TaskFlowTests: XCTestCase {
     }
     
     func test_execute_and_complete_a_task() {
-        let task = Task { flow, _ in
+        let task = SCTask { flow, _ in
             flow.finish()
         }
         
         let exp = expectation(description: "Wait for task completion")
         
-        let sequence = TaskSequence(tasks: task)
+        let sequence = SCTaskSequence(tasks: task)
         sequence.whenDone { state in
             switch state {
             case .finished:
@@ -30,13 +30,13 @@ final class TaskFlowTests: XCTestCase {
     }
     
     func test_execute_and_cancel_a_task() {
-        let task = Task { flow, _ in
+        let task = SCTask { flow, _ in
             flow.cancel()
         }
         
         let exp = expectation(description: "Wait for task completion")
         
-        let sequence = TaskSequence(tasks: task)
+        let sequence = SCTaskSequence(tasks: task)
         sequence.whenDone { state in
             switch state {
             case .canceled:
@@ -52,13 +52,13 @@ final class TaskFlowTests: XCTestCase {
     }
     
     func test_execute_and_finish_a_task_with_an_error() {
-        let task = Task { flow, _ in
+        let task = SCTask { flow, _ in
             flow.finish(TestTaskError.genericError)
         }
         
         let exp = expectation(description: "Wait for task completion")
         
-        let sequence = TaskSequence(tasks: task)
+        let sequence = SCTaskSequence(tasks: task)
         sequence.whenDone { state in
             switch state {
             case .failed(let error):
@@ -80,13 +80,13 @@ final class TaskFlowTests: XCTestCase {
     func test_execute_and_complete_a_task_passing_a_result() {
         let expectedResult = 2112
         
-        let task = Task { flow, _ in
+        let task = SCTask { flow, _ in
             flow.finish(expectedResult)
         }
         
         let exp = expectation(description: "Wait for task completion")
         
-        let sequence = TaskSequence(tasks: task)
+        let sequence = SCTaskSequence(tasks: task)
         sequence.whenDone { state in
             switch state {
             case .finished(let result):
@@ -112,11 +112,11 @@ final class TaskFlowTests: XCTestCase {
         let initialResult = 2
         let secondResult = 2
         
-        let firstTask = Task { flow, _ in
+        let firstTask = SCTask { flow, _ in
             flow.finish(initialResult)
         }
         
-        let secondTask = Task { flow, previousResult in
+        let secondTask = SCTask { flow, previousResult in
             guard let previousResult = previousResult as? Int else {
                 flow.finish(TestTaskError.expectedIntegerPreviousResult)
                 return
@@ -126,7 +126,7 @@ final class TaskFlowTests: XCTestCase {
         
         let exp = expectation(description: "Wait for task completion")
         
-        let sequence = TaskSequence(tasks: firstTask, secondTask)
+        let sequence = SCTaskSequence(tasks: firstTask, secondTask)
         sequence.whenDone { state in
             switch state {
             case .finished(let result):


### PR DESCRIPTION
Also renamed all sibling structs 
This due to the fact that Apple has released their own Task object on Concurrency framework