### PR TITLE
Set minimum iOS version to 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "ShortcutFoundation",
     platforms: [
-        .iOS(.v14),
+        .iOS(.v13),
         .macOS(.v11),
         .watchOS(.v6)
     ],

--- a/Tests/ShortcutFoundationTests/StringExtensionTests.swift
+++ b/Tests/ShortcutFoundationTests/StringExtensionTests.swift
@@ -39,7 +39,7 @@ final class StringExtensionTests: XCTestCase {
     }
     
     func test_month() {
-        let expectedMonth = "Aug"
+        let expectedMonth = "August"
         let month = String.getDateString(date: .nineteenthAugust2021, format: .month)
         XCTAssertEqual(month, expectedMonth)
     }


### PR DESCRIPTION
Set minimum iOS version to 13. No build warnings found.