### PR TITLE
Empty String extension

### DIFF
--- a/Sources/ShortcutFoundation/Extensions/String+Extension.swift
+++ b/Sources/ShortcutFoundation/Extensions/String+Extension.swift
@@ -6,6 +6,9 @@ public enum PersonalNumberGender {
 }
 
 public extension String {
+    
+    static let empty = ""
+    
     static var buildString: String {
         let version = Bundle.main.releaseVersionNumber ?? ""
         let build = Bundle.main.buildVersionNumber ?? ""


### PR DESCRIPTION
Super simple, but I think it makes the code nicer to call `.empty` instead of `""`