### PR TITLE
Fixed issue with upload task.

### DIFF
--- a/Sources/ShortcutFoundation/Core/Network/Core/Calls/NetworkingClient+Multipart.swift
+++ b/Sources/ShortcutFoundation/Core/Network/Core/Calls/NetworkingClient+Multipart.swift
@@ -21,7 +21,7 @@ public extension NetworkingClient {
                     throw NetworkingError.init(status: .cancelled)
                 }
                 
-                if let data = data, progress.isFinished {
+                if let data = data {
                     return (try decoder.decode(T.self, from: data), progress)
                 } else {
                     return (nil, progress)


### PR DESCRIPTION
For some reason the Progress of an upload task can in some cases revert back to 0% finished when completed. 
This removes the check for progress.finished to complete the upload and is instead relying on decoding of the response from the backend.