### PR TITLE
Wrapper for authentication using biometrics

### DIFF
--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
@@ -1,0 +1,90 @@
+//
+//  DeviceAuthentication.swift
+//  
+//
+//  Created by Swathi on 2022-02-02.
+//
+
+import LocalAuthentication
+
+//Current state if authentication
+public enum DeviceAuthAction: Equatable {
+    case authenticated
+    case notAuthenticated
+    case error(BiometricError)
+}
+
+//Error states while authentication
+public enum BiometricError: Swift.Error {
+    case unsupportedDevice
+    case failed
+}
+
+public final class DeviceAuthentication: ObservableObject {
+    
+    var alertDescription: String
+    private var context: DeviceContextProtocol
+    
+    @Published public private(set) var action: DeviceAuthAction
+    {
+        didSet {
+            if action == .notAuthenticated {
+                context = LAContext()
+            }
+        }
+    }
+    
+    /// Indicates what type is supported by the  device
+    public var type: LABiometryType {
+        context.biometryType
+    }
+
+    /// Indicates if biometrics are supported
+    public var isBiometricsSupported: Bool {
+        context.biometryType != .none
+    }
+    
+    public init(context: DeviceContextProtocol = LAContext(),
+                localizedAlertDesc: String) {
+        self.context = context
+        self.alertDescription = localizedAlertDesc
+
+        // Context can set the biometric type
+        context.canEvaluatePolicy(.deviceOwnerAuthentication,
+                                  error: nil)
+        action = .notAuthenticated
+    }
+    
+    /// Attempt to authenticate the user with biometrics. Updates action with the result
+    public func login() {
+        var error: NSError?
+        // Determine if the device supports biometrics, else return error.
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication,
+                                        error: &error) else {
+            action = .error(.unsupportedDevice)
+            return
+        }
+
+        // Ensures a new context is provided for authentication, else the previous one will always fail to re-auth
+        if action == .authenticated {
+            action = .notAuthenticated
+        }
+
+        //authenticate user using biometrics or the user's device passcode.
+        //.deviceOwnerAuthenticationWithBiometrics - only faceID/touchId
+        context.evaluatePolicy(.deviceOwnerAuthentication,
+                               localizedReason: alertDescription) { [weak self] success, _ in
+            // Ensure that the action is updated on main thread
+            DispatchQueue.main.async {
+                self?.action = success ? .authenticated : .error(.failed)
+            }
+        }
+    }
+
+    //Logout if authenticated. Else no state change needed
+    public func logout() {
+        if action == .authenticated {
+            action = .notAuthenticated
+        }
+    }
+}

--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
@@ -1,0 +1,23 @@
+//
+//  DeviceContextProtocol.swift
+//  
+//
+//  Created by Swathi on 2022-02-02.
+//
+
+import Foundation
+import LocalAuthentication
+
+public protocol DeviceContextProtocol {
+    var biometryType: LABiometryType { get }
+    
+    @discardableResult
+    func canEvaluatePolicy(_ policy: LAPolicy,
+                           error: NSErrorPointer) -> Bool
+    func evaluatePolicy(_ policy: LAPolicy,
+                        localizedReason: String,
+                        reply: @escaping (Bool, Error?) -> Void)
+}
+
+extension LAContext: DeviceContextProtocol {}
+

--- a/Tests/ShortcutFoundationTests/Biometrics/DeviceAuthenticationTests.swift
+++ b/Tests/ShortcutFoundationTests/Biometrics/DeviceAuthenticationTests.swift
@@ -1,0 +1,237 @@
+//
+//  DeviceAuthenticationTests.swift
+//  
+//
+//  Created by Swathi on 2022-02-02.
+//
+
+import XCTest
+import Combine
+
+@testable import ShortcutFoundation
+
+class DeviceAuthenticationTests: XCTestCase {
+    
+    private let timeout: TimeInterval = 3.0
+    private let dispatchDelay = 0.5
+
+    private var cancelleables = Set<AnyCancellable>()
+
+    func testNoDeviceBiometrics() {
+        let context = MockDeviceContext()
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "test device biometrics is none")
+        XCTAssertEqual(deviceAuth.type, .none)
+        XCTAssertFalse(deviceAuth.isBiometricsSupported)
+    }
+
+    func testFaceIDSupport() {
+        let context = MockDeviceContext(type: .faceID)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "test faceID biometrics")
+        
+        XCTAssertEqual(deviceAuth.type, .faceID)
+        XCTAssertTrue(deviceAuth.isBiometricsSupported)
+    }
+
+    func testTouchIDSupport() {
+        let context = MockDeviceContext(type: .touchID)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                      localizedAlertDesc: "test touchID biometrics")
+        XCTAssertEqual(deviceAuth.type, .touchID)
+        XCTAssertTrue(deviceAuth.isBiometricsSupported)
+    }
+
+    func testLoginNoID() {
+        let context = MockDeviceContext()
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "test biometrics unavailable")
+        
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+        
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst()
+            .sink { action in
+                switch action {
+                case let .error(error):
+                    switch error {
+                    case .unsupportedDevice:
+                        expect.fulfill()
+                    default:
+                        XCTFail("Unexpected result")
+                    }
+                    
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+        
+        deviceAuth.login()
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testLoginFaceID() {
+        let context = MockDeviceContext(type: .faceID, isAuthenticated: true)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithFaceID")
+        
+        
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst()
+            .sink { action in
+                switch action {
+                case .authenticated:
+                    expect.fulfill()
+
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.login()
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    func testLoginFaceIDFailed() {
+        let context = MockDeviceContext(type: .faceID)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithFaceID")
+        
+        
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst()
+            .sink { action in
+                switch action {
+                case let .error(error):
+                    switch error {
+                    case .failed:
+                        expect.fulfill()
+
+                    default:
+                        XCTFail("Unexpected result")
+                    }
+
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.login()
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testLoginTouchID() {
+        let context = MockDeviceContext(type: .touchID, isAuthenticated: true)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithTouchID")
+        
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst()
+            .sink { action in
+                switch action {
+                case .authenticated:
+                    expect.fulfill()
+
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.login()
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testRepeatLoginTouchID() {
+        let context = MockDeviceContext(type: .touchID,
+                                        isAuthenticated: true)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithTouchID")
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst(3)
+            .sink { action in
+                switch action {
+                case .authenticated:
+                    expect.fulfill()
+
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.login()
+        // The response is queued on main and requires a delay to complete
+        DispatchQueue.main.asyncAfter(deadline: .now() + dispatchDelay) {
+            deviceAuth.login()
+        }
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    
+
+    func testSignOut() {
+        let context = MockDeviceContext(type: .touchID, isAuthenticated: true)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithTouchID")
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        let expect = expectation(description: "expect")
+        deviceAuth.$action
+            .dropFirst(2)
+            .sink { action in
+                switch action {
+                case .notAuthenticated:
+                    expect.fulfill()
+
+                default:
+                    XCTFail("Unexpected result")
+                }
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.login()
+        DispatchQueue.main.asyncAfter(deadline: .now() + dispatchDelay) {
+            deviceAuth.logout()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testSignOutFailed() {
+        let context = MockDeviceContext(type: .touchID, isAuthenticated: true)
+        let deviceAuth = DeviceAuthentication(context: context,
+                                              localizedAlertDesc: "loginWithTouchID")
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+
+        deviceAuth.$action
+            .dropFirst()
+            .sink { _ in
+                XCTFail("Unexpected result")
+            }
+            .store(in: &cancelleables)
+
+        deviceAuth.logout()
+        XCTAssertEqual(deviceAuth.action, .notAuthenticated)
+    }
+}

--- a/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
+++ b/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
@@ -1,0 +1,40 @@
+//
+//  MockDeviceContext.swift
+//  
+//
+//  Created by Swathi on 2022-02-02.
+//
+
+import Foundation
+import LocalAuthentication
+import ShortcutFoundation
+
+public final class MockDeviceContext: DeviceContextProtocol {
+    
+    private let type: LABiometryType
+
+    public var mockEvaluateReply: (Bool, Error?) = (false, nil)
+
+    public var biometryType: LABiometryType { type }
+
+    public var localizedCancelTitle: String?
+
+    public init(type: LABiometryType = .none,
+                isAuthenticated: Bool = false) {
+        self.type = type
+        if isAuthenticated {
+            mockEvaluateReply = (true, nil)
+        }
+    }
+
+    public func canEvaluatePolicy(_: LAPolicy,
+                                  error _: NSErrorPointer) -> Bool {
+        type != .none
+    }
+
+    public func evaluatePolicy(_: LAPolicy,
+                               localizedReason _: String,
+                               reply: @escaping (Bool, Error?) -> Void) {
+        reply(mockEvaluateReply.0, mockEvaluateReply.1)
+    }
+}

--- a/Tests/ShortcutFoundationTests/XCTestManifests.swift
+++ b/Tests/ShortcutFoundationTests/XCTestManifests.swift
@@ -3,7 +3,8 @@ import XCTest
 #if !canImport(ObjectiveC)
 public func allTests() -> [XCTestCaseEntry] {
     return [
-        testCase(InjectionTests.allTests)
+        testCase(InjectionTests.allTests),
+        estCase(DeviceAuthenticationTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
A helper class to enable device authentication. In my previous client project, it was used before the payment flow started or to check if the user was allowed to see wallet details.