### PR TITLE
Update build scripts for local run

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   run-tests:
 
-    runs-on: self-hosted
+    runs-on: sweden
     timeout-minutes: 20
 
     steps:


### PR DESCRIPTION
Changing build script `runs-on`  `sweden` instead of `self-hosted`.

Our local build server has both of these tags enabled so the change should not impact anything but it will make sure that we dont run on a Norwegian or Danish machine if they setup any in the future 