### PR TITLE
Make Loggable take autoclosure

### DIFF
--- a/Sources/ShortcutFoundation/Core/Logger/Loggable.swift
+++ b/Sources/ShortcutFoundation/Core/Logger/Loggable.swift
@@ -56,14 +56,14 @@ public protocol Loggable {
     /// - Author: Gabriel Sabadin
     ///
     /// - Parameter message: A String to determine the message you want to be logged
-    func log(message: String)
+    func log(message: @autoclosure @escaping () -> String)
 
     /// Method that triggers the logging procedure
     /// - Author: Gabriel Sabadin
     ///
     /// - Parameter message: A String to determine the message you want to be logged
     /// - Parameter message: A verbosity argument to have the flexibility to use different verbosity
-    func log(message: String, verbosity: Verbosity)
+    func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity)
 }
 
 struct PrintLogger: Loggable {
@@ -73,22 +73,22 @@ struct PrintLogger: Loggable {
         self.verbosity = verbosity
     }
 
-    func log(message: String) {
-        log(message: message, verbosity: verbosity)
+    func log(message: @autoclosure @escaping () -> String) {
+        log(message: message(), verbosity: verbosity)
     }
 
-    func log(message: String, verbosity: Verbosity) {
+    func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity) {
         switch verbosity {
         case .debug:
-            print("🕵️‍♀️ DEBUG: \(message)")
+            print("🕵️‍♀️ DEBUG: \(message())")
         case .info:
-            print("ℹ️ INFO: \(message)")
+            print("ℹ️ INFO: \(message())")
         case .warning:
-            print("⚠️ WARNING: \(message)")
+            print("⚠️ WARNING: \(message())")
         case .error:
-            print("⛔️ ERROR: \(message)")
+            print("⛔️ ERROR: \(message())")
         case .critical:
-            print("☣️ CRITICAL: \(message)")
+            print("☣️ CRITICAL: \(message())")
         case .silent:
             // no log message message
             break
@@ -107,22 +107,22 @@ struct AppleLogger: Loggable {
         logger = os.Logger(subsystem: identifier, category: category)
     }
 
-    func log(message: String) {
-        log(message: message, verbosity: verbosity)
+    func log(message: @autoclosure @escaping () -> String) {
+        log(message: message(), verbosity: verbosity)
     }
 
-    func log(message: String, verbosity: Verbosity) {
+    func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity) {
         switch verbosity {
         case .debug:
-            logger.debug("\(message)")
+            logger.debug("\(message())")
         case .info:
-            logger.info("\(message)")
+            logger.info("\(message())")
         case .warning:
-            logger.warning("\(message)")
+            logger.warning("\(message())")
         case .error:
-            logger.error("\(message)")
+            logger.error("\(message())")
         case .critical:
-            logger.critical("\(message)")
+            logger.critical("\(message())")
         case .silent:
             // no log message message
             break
@@ -150,11 +150,11 @@ public struct Logger: Loggable {
         }
     }
 
-    public func log(message: String) {
-        strategy.log(message: message)
+    public func log(message: @autoclosure @escaping () -> String) {
+        strategy.log(message: message())
     }
 
-    public func log(message: String, verbosity: Verbosity) {
-        strategy.log(message: message, verbosity: verbosity)
+    public func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity) {
+        strategy.log(message: message(), verbosity: verbosity)
     }
 }

--- a/Sources/ShortcutFoundation/Core/Logger/Loggable.swift
+++ b/Sources/ShortcutFoundation/Core/Logger/Loggable.swift
@@ -52,18 +52,31 @@ public protocol Loggable {
     /// - Parameter category: A String to determine the category of the logger
     init(verbosity: Verbosity, identifier: String, category: String)
 
-    /// Method that triggers the logging procedure
+    /// Method that triggers the logging procedure using a string returned from a closure
     /// - Author: Gabriel Sabadin
     ///
     /// - Parameter message: A String to determine the message you want to be logged
     func log(message: @autoclosure @escaping () -> String)
 
-    /// Method that triggers the logging procedure
+    /// Method that triggers the logging procedure using a string returned from a closure
     /// - Author: Gabriel Sabadin
     ///
     /// - Parameter message: A String to determine the message you want to be logged
-    /// - Parameter message: A verbosity argument to have the flexibility to use different verbosity
+    /// - Parameter verbosity: A verbosity argument to have the flexibility to use different verbosity
     func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity)
+    
+    /// Method that triggers the logging procedure using fixed text.
+    /// - Author: Gabriel Sabadin
+    ///
+    /// - Parameter message: A String to determine the message you want to be logged
+    /// - Parameter verbosity: A verbosity argument to have the flexibility to use different verbosity
+    func logText(message: String, verbosity: Verbosity)
+    
+    /// Method that triggers the logging procedure using fixed text.
+    /// - Author: Gabriel Sabadin
+    ///
+    /// - Parameter message: A String to determine the message you want to be logged
+    func logText(message: String)
 }
 
 struct PrintLogger: Loggable {
@@ -93,6 +106,14 @@ struct PrintLogger: Loggable {
             // no log message message
             break
         }
+    }
+    
+    func logText(message: String) {
+        log(message: message)
+    }
+    
+    func logText(message: String, verbosity: Verbosity) {
+        log(message: message, verbosity: verbosity)
     }
 }
 
@@ -128,6 +149,14 @@ struct AppleLogger: Loggable {
             break
         }
     }
+    
+    func logText(message: String) {
+        log(message: message)
+    }
+    
+    func logText(message: String, verbosity: Verbosity) {
+        log(message: message, verbosity: verbosity)
+    }
 }
 
 @available(watchOS 7.0, *)
@@ -156,5 +185,13 @@ public struct Logger: Loggable {
 
     public func log(message: @autoclosure @escaping () -> String, verbosity: Verbosity) {
         strategy.log(message: message(), verbosity: verbosity)
+    }
+    
+    public func logText(message: String) {
+        log(message: message)
+    }
+    
+    public func logText(message: String, verbosity: Verbosity) {
+        log(message: message, verbosity: verbosity)
     }
 }


### PR DESCRIPTION
In summary, this is a very rarely needed performance optimization.

This feature makes Loggable take arguments as `@autoclosure`. Autoclosure is syntactic sugar for the compiler to convert expressions into a closure before passing them as an argument to the function. In effect, this delays the *execution* of the logged statement until it is being logged, or for `silent` verbosity, the expression is never made.

This does not make a big difference for simple logs such as:
```swift
logger.log(message: "Hello World!")
```

However it makes a big difference if a heavy computation is performed in the log, for instance:
```swift
logger.log(message: "\(bigArray.map { $0.heavyComputation() } )")
logger.log(message: "All users: \(users.sorted())")
```