### PR TITLE
Enable all platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     platforms: [
         .iOS(.v13),
         .macOS(.v11),
+        .tvOS(.v14),
         .watchOS(.v6)
     ],
     products: [

--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
@@ -22,7 +22,7 @@ public enum DeviceAuthError: Error {
     case failed
 }
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(tvOS)
 public final class DeviceAuthentication: ObservableObject {
 
     public var alertDescription: String

--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceAuthentication.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(LocalAuthentication)
 import LocalAuthentication
 
 // Current state if authentication
@@ -84,4 +85,5 @@ public final class DeviceAuthentication: ObservableObject {
         }
     }
 }
+#endif
 #endif

--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(LocalAuthentication)
 import Foundation
 import LocalAuthentication
 
@@ -22,4 +23,5 @@ public protocol DeviceContextProtocol {
 }
 
 extension LAContext: DeviceContextProtocol {}
+#endif
 #endif

--- a/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
+++ b/Sources/ShortcutFoundation/Core/Device/Biometrics/DeviceContextProtocol.swift
@@ -10,7 +10,7 @@
 import Foundation
 import LocalAuthentication
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(tvOS)
 public protocol DeviceContextProtocol {
     var biometryType: LABiometryType { get }
 

--- a/Sources/ShortcutFoundation/Core/Payment/ApplePayAuthorizationHandler.swift
+++ b/Sources/ShortcutFoundation/Core/Payment/ApplePayAuthorizationHandler.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import PassKit
 
 public final class ApplePayAuthorizationHandler {
@@ -80,3 +81,4 @@ public final class ApplePayAuthorizationHandler {
         completion(.success(paymentVC))
     }
 }
+#endif

--- a/Sources/ShortcutFoundation/Core/Payment/PaymentManager.swift
+++ b/Sources/ShortcutFoundation/Core/Payment/PaymentManager.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import Foundation
 import PassKit
 
@@ -64,4 +65,6 @@ extension PaymentManager: PKPaymentAuthorizationControllerDelegate {
         }
     }
 }
+#endif
+
 #endif

--- a/Sources/ShortcutFoundation/Core/Payment/PaymentManager.swift
+++ b/Sources/ShortcutFoundation/Core/Payment/PaymentManager.swift
@@ -45,6 +45,12 @@ public final class PaymentManager: NSObject, IPaymentManager {
 }
 
 extension PaymentManager: PKPaymentAuthorizationControllerDelegate {
+    #if !os(watchOS) && !os(tvOS)
+    // Needed for iOS 14, macOS, and Catalyst
+    public func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
+        nil
+    }
+    #endif
 
     public func paymentAuthorizationControllerDidFinish(_ controller: PKPaymentAuthorizationController) {
         paymentController?.dismiss(completion: nil)

--- a/Sources/ShortcutFoundation/Core/Payment/RemotePaymentProvider.swift
+++ b/Sources/ShortcutFoundation/Core/Payment/RemotePaymentProvider.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import Foundation
 import PassKit
 
@@ -22,3 +23,5 @@ public class RemotePaymentProvider: PaymentProvider {
         completion(nil)
     }
 }
+
+#endif

--- a/Tests/ShortcutFoundationTests/Biometrics/DeviceAuthenticationTests.swift
+++ b/Tests/ShortcutFoundationTests/Biometrics/DeviceAuthenticationTests.swift
@@ -3,7 +3,7 @@ import Combine
 
 @testable import ShortcutFoundation
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(tvOS)
 class DeviceAuthenticationTests: XCTestCase {
     
     private let timeout: TimeInterval = 5.0

--- a/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
+++ b/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
@@ -3,7 +3,7 @@ import Foundation
 import LocalAuthentication
 import ShortcutFoundation
 
-#if !os(watchOS)
+#if !os(watchOS) && !os(tvOS)
 public final class MockDeviceContext: DeviceContextProtocol {
     
     private let type: LABiometryType

--- a/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
+++ b/Tests/ShortcutFoundationTests/Biometrics/MockDeviceContext.swift
@@ -1,3 +1,4 @@
+#if canImport(LocalAuthentication)
 import Foundation
 import LocalAuthentication
 import ShortcutFoundation
@@ -32,4 +33,5 @@ public final class MockDeviceContext: DeviceContextProtocol {
         reply(mockEvaluateReply.0, mockEvaluateReply.1)
     }
 }
+#endif
 #endif

--- a/Tests/ShortcutFoundationTests/Fixtures/Date+.swift
+++ b/Tests/ShortcutFoundationTests/Fixtures/Date+.swift
@@ -2,6 +2,7 @@ import Foundation
 
 extension Date {
     static var nineteenthAugust2021: Date {
-        return Date(timeIntervalSince1970: TimeInterval(1629346343143/1000))
+        let time: UInt64 = 1629346343143
+        return Date(timeIntervalSince1970: TimeInterval(time/1000))
     }
 }

--- a/Tests/ShortcutFoundationTests/KeychainTests.swift
+++ b/Tests/ShortcutFoundationTests/KeychainTests.swift
@@ -22,7 +22,7 @@ final class KeychainTests: XCTestCase {
     }
     
     func test_saving_reading_and_deleting_codable() {
-        let expectedValue = KeychainTestData(name: "Gabriel", createdAt: .now)
+        let expectedValue = KeychainTestData(name: "Gabriel", createdAt: Date())
         codableSUT = expectedValue
         
         XCTAssertNotNil(codableSUT)

--- a/Tests/ShortcutFoundationTests/Payment/ApplePayAuthorizationTests.swift
+++ b/Tests/ShortcutFoundationTests/Payment/ApplePayAuthorizationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import PassKit
 import XCTest
 import ShortcutFoundation
@@ -80,3 +81,4 @@ class ApplePayAuthorizationTests: XCTestCase {
         wait(for: [exp], timeout: 1.0)
     }
 }
+#endif

--- a/Tests/ShortcutFoundationTests/Payment/PassKit+TestHelpers.swift
+++ b/Tests/ShortcutFoundationTests/Payment/PassKit+TestHelpers.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import PassKit
 import ShortcutFoundation
 
@@ -70,3 +71,4 @@ extension PaymentModel {
                             currency: TestStrings.invalidCurrency.rawValue)
     }
 }
+#endif

--- a/Tests/ShortcutFoundationTests/Payment/PaymentManagerTests.swift
+++ b/Tests/ShortcutFoundationTests/Payment/PaymentManagerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import PassKit
 import XCTest
 @testable import ShortcutFoundation
@@ -34,4 +35,6 @@ class PaymentManagerTests: XCTestCase {
         PKPaymentAuthorizationController(paymentRequest: .validRequest)
     }
 }
+#endif
+
 #endif

--- a/Tests/ShortcutFoundationTests/Payment/PaymentProviderSpy.swift
+++ b/Tests/ShortcutFoundationTests/Payment/PaymentProviderSpy.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Shortcut Scandinavia Apps AB. All rights reserved.
 //
 
+#if canImport(PassKit)
 import PassKit
 import ShortcutFoundation
 
@@ -16,3 +17,4 @@ class PaymentProviderSpy: PaymentProvider {
         payments.append(payment)
     }
 }
+#endif

--- a/Tests/ShortcutFoundationTests/StringExtensionTests.swift
+++ b/Tests/ShortcutFoundationTests/StringExtensionTests.swift
@@ -5,7 +5,7 @@ final class StringExtensionTests: XCTestCase {
     func test_age_from_personal_number() {
         let calendar = Calendar.current
         let dateOfBirth = calendar.date(from: .init(year: 1985, month: 04, day: 23))!
-        let expectedAge = calendar.dateComponents([.year], from: dateOfBirth, to: .now).year
+        let expectedAge = calendar.dateComponents([.year], from: dateOfBirth, to: Date()).year
 
         let sut = "198504230000"
         let age = sut.ageFromPersonalNumber
@@ -14,7 +14,7 @@ final class StringExtensionTests: XCTestCase {
     
     func test_negative_futute_age_from_personal_number() {
         let dateOfBirth = Calendar.current.date(from: .init(year: 1985, month: 12, day: 23))!
-        let expectedAge = Calendar.current.dateComponents([.year], from: dateOfBirth, to: .now).year
+        let expectedAge = Calendar.current.dateComponents([.year], from: dateOfBirth, to: Date()).year
         let sut = "198512230000"
         let age = sut.ageFromPersonalNumber
         XCTAssertEqual(age, expectedAge)


### PR DESCRIPTION
Building and testing did not actually work on all platform options that were declare in Package.swift. Also, tvOS was not listed in there. Now everything builds correctly for all platforms (both actual and simulator), and all tests pass on all platforms.