### PR TITLE
Handling decoding of NetworkingRequests query parameters

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/ShortcutFoundation.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/ShortcutFoundation.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ShortcutFoundation"
+               BuildableName = "ShortcutFoundation"
+               BlueprintName = "ShortcutFoundation"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:ShortcutFoundation.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "ShortcutFoundationTests"
+               BuildableName = "ShortcutFoundationTests"
+               BlueprintName = "ShortcutFoundationTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "en"
+      region = "US"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "ShortcutFoundation"
+            BuildableName = "ShortcutFoundation"
+            BlueprintName = "ShortcutFoundation"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.8
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,8 +6,8 @@ import PackageDescription
 let package = Package(
     name: "ShortcutFoundation",
     platforms: [
-        .iOS(.v13),
-        .macOS(.v11),
+        .iOS(.v16),
+        .macOS(.v12),
         .tvOS(.v14),
         .watchOS(.v6)
     ],

--- a/ShortcutFoundation.xctestplan
+++ b/ShortcutFoundation.xctestplan
@@ -1,0 +1,29 @@
+{
+  "configurations" : [
+    {
+      "id" : "EBA17688-D700-4501-8039-362F1CB230C9",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en",
+    "locationScenario" : {
+      "identifier" : "New York, NY, USA",
+      "referenceType" : "built-in"
+    },
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "ShortcutFoundationTests",
+        "name" : "ShortcutFoundationTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Tests/ShortcutFoundationTests/Network/NetworkingRequestTests.swift
+++ b/Tests/ShortcutFoundationTests/Network/NetworkingRequestTests.swift
@@ -1,0 +1,50 @@
+//
+//  NetworkingRequestTests.swift
+//  
+//
+//  Created by Karl Söderberg on 2024-08-12.
+//
+
+import XCTest
+@testable import ShortcutFoundation
+
+final class NetworkingRequestTests: XCTestCase {
+
+    struct MyPayload: Encodable {
+        let name: String
+        let age: Int
+    }
+
+    func testURL() throws {
+        let url = URL(string: "www.google.com")!
+        let request = NetworkingRequest<String>()
+        request.baseURL = "www.google.com"
+        let urlRequest = request.buildURLRequest()
+        XCTAssertEqual(urlRequest?.url, url)
+    }
+
+    func testURLWithQueryParams() throws {
+        let payload = MyPayload(name: "Kalle", age: 38)
+
+        let request = NetworkingRequest<MyPayload>()
+        request.baseURL = "www.google.com"
+        request.params = payload
+        let urlRequest = request.buildURLRequest()
+
+        let url = URL(string: "www.google.com?name=Kalle&age=38")!
+        XCTAssertEqual(urlRequest?.url, url)
+    }
+
+    func testURLShouldNotHaveQueryParamsIfPost() throws {
+        let payload = MyPayload(name: "Kalle", age: 38)
+
+        let request = NetworkingRequest<MyPayload>()
+        request.baseURL = "www.google.com"
+        request.params = payload
+        request.httpVerb = .post
+        let urlRequest = request.buildURLRequest()
+
+        let url = URL(string: "www.google.com")!
+        XCTAssertEqual(urlRequest?.url, url)
+    }
+}


### PR DESCRIPTION
Previously the query parameters where handled by doing a mirror of the payload object and then inserting each item as a query param. This does not respect any custom encoding in the payload so this PR fixes that by using a encoded version of the Payload to create the query params. 
Still keeps the old way if the new fails for some reason.